### PR TITLE
Sean McNamara PR 4/13/22 3:02 pm - Merge With Hunter

### DIFF
--- a/src/components/common/StarsContainer.jsx
+++ b/src/components/common/StarsContainer.jsx
@@ -2,7 +2,6 @@
 import React, { useState, useEffect } from 'react';
 import 'whatwg-fetch';
 import { getStars, calculateTotalReviewNumber, calculateAverage } from './helpers.js';
-import styled from 'styled-components';
 import {AllStars, StarsAndReviews, Star, ReviewLink, MergeStar, FirstStarPortion, SecondStarPortion} from './StarsContainerStyles.jsx';
 
 const StarsContainer = ({ currentItem, onReviewLinkClick, starsAndReviews, singleReview, singleRating }) => {

--- a/src/components/productOverview/addToCart/AddToCart.jsx
+++ b/src/components/productOverview/addToCart/AddToCart.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable */
 import React from 'react';
-import styled from 'styled-components';
 import {AddToCartButton} from './AddToCartStyles.jsx';
 
 const AddToCart = ({currentStyle, currentSize, onAddToCartClick, onAddToCartClickNoSize}) => {

--- a/src/components/productOverview/addToCart/AddToCartStyles.jsx
+++ b/src/components/productOverview/addToCart/AddToCartStyles.jsx
@@ -4,15 +4,16 @@ import styled from 'styled-components';
 export const AddToCartButton = styled.button`
   all: unset;
   display: flex;
+  background-color: white;
+  color: black;
   justify-content: space-between;
   align-items: center;
   height: 100%;
   width: 100%;
-  background-color: white;
   padding:0.35em 1.2em;
   border:0.1em solid black;
   margin:0 0.3em 0.3em 0;
-  border-radius: 3px;
+  border-radius: 10px;
   box-sizing: border-box;
   box-shadow: 0 0 2px black;
   text-decoration:none;
@@ -20,7 +21,7 @@ export const AddToCartButton = styled.button`
   font-family:'Roboto',sans-serif;
   font-weight:300;
   &:hover {
-    box-shadow: 0 0 5px rgb(222, 99, 23);
-    color: rgb(222, 99, 23);
+    box-shadow: 0 0 5px rgb(59, 167, 184);
+    color: rgb(59, 167, 184);
   }
 `;

--- a/src/components/productOverview/imageGallery/DefaultView.jsx
+++ b/src/components/productOverview/imageGallery/DefaultView.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable */
 import React, {useState} from 'react';
-import styled from 'styled-components';
 import {DefaultGallery} from './ImageGalleryStyles.jsx';
 
 const DefaultView = ({image, onGalleryButtonClick, currentView, onImageClick}) => {

--- a/src/components/productOverview/imageGallery/ExpandedView.jsx
+++ b/src/components/productOverview/imageGallery/ExpandedView.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable */
 import React, {useState, useEffect} from 'react';
-import styled from 'styled-components';
 import {EntireExpandedView, ExpandedContainer, ZoomedImage, ZoomedContainer, ExpandedImage, Icons, Icon, SelectedIcon} from './ImageGalleryStyles.jsx';
 
 const ExpandedView = ({currentStyle, currentImage, onRestoreDefaultClick}) => {

--- a/src/components/productOverview/imageGallery/ImageGallery.jsx
+++ b/src/components/productOverview/imageGallery/ImageGallery.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable */
 import React, {useState, useEffect} from 'react';
-import styled from 'styled-components';
 import DefaultView from './DefaultView.jsx';
 import ThumbnailCarousel from './ThumbnailCarousel.jsx';
 import {ImageGalleryComponent} from './ImageGalleryStyles.jsx';

--- a/src/components/productOverview/imageGallery/ImageGalleryStyles.jsx
+++ b/src/components/productOverview/imageGallery/ImageGalleryStyles.jsx
@@ -9,7 +9,7 @@ export const ImageGalleryComponent = styled.div`
   box-sizing: border-box;
   background-color: grey;
   box-shadow: 0 0 5px black;
-  border-radius: 3px;
+  border-radius: 10px;
   margin: 20px 40px 40px 60px;
   min-height: 100%;
   width: 65%;
@@ -31,7 +31,7 @@ export const Thumbnail = styled.img `
   opacity: 70%;
   border: 1px solid black;
   box-shadow: -0px 0px 3px black;
-  border-radius: 3px;
+  border-radius: 10px;
   margin: 5px;
 `;
 export const SelectedContainer = styled.div`
@@ -47,7 +47,7 @@ export const SelectedThumbnail = styled.img `
   max-width: 55px;
   border: 1px solid rgb(222, 99, 23);
   box-shadow: -0px 0px 3px rgb(222, 99, 23);
-  border-radius: 3px;
+  border-radius: 10px;
   margin: 5px;
   margin-bottom: 2px;
 `;
@@ -57,7 +57,7 @@ export const SelectedThumbnailUnderline = styled.div `
   width: 55px;
   border-bottom: 3px solid rgb(222, 99, 23);
   box-shadow: -1px 1px 1px rgb(222, 99, 23);
-  border-radius: 3px;
+  border-radius: 10px;
   margin-bottom: 5px;
 `;
 
@@ -69,7 +69,7 @@ export const EntireExpandedView = styled.div`
   background-color: grey;
   justify-content: center;
   box-sizing: border-box;
-  border-radius: 3px;
+  border-radius: 10px;
   box-shadow: 0 0 5px black;
   margin: 20px 60px 40px 60px;
 `;
@@ -87,7 +87,7 @@ export const ZoomedImage = styled.img`
   transform: scale(2.5);
   object-fit: fill;
   box-sizing: border-box;
-  border-radius: 3px;
+  border-radius: 10px;
   box-shadow: 0 0 5px black;
   height: 100%;
   width: 50%;
@@ -102,7 +102,7 @@ export const ZoomedContainer = styled.div`
   align-items: center;
   box-sizing: border-box;
   box-shadow: 0 0 5px black;
-  border-radius: 3px;
+  border-radius: 10px;
   background-color: grey;
   padding: 60px;
   margin: 20px 60px 20px 60px;
@@ -115,7 +115,7 @@ export const ExpandedImage = styled.img`
   object-fit: cover;
   max-width: 75%;
   height: 95%;
-  border-radius: 3px;
+  border-radius: 10px;
   box-shadow: 0 0 5px black;
   overflow: hidden;
   cursor: crosshair;

--- a/src/components/productOverview/imageGallery/ThumbnailCarousel.jsx
+++ b/src/components/productOverview/imageGallery/ThumbnailCarousel.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable */
 import React, {useState} from 'react';
-import styled from 'styled-components';
 import {ThumbnailContainer, Thumbnail, SelectedContainer, SelectedThumbnail, SelectedThumbnailUnderline} from './ImageGalleryStyles.jsx';
 
 const ThumbnailCarousel = ({photosArray, onThumbnailImageClick, currentStylePhotoIndex}) => {

--- a/src/components/productOverview/productInfo/IconList.jsx
+++ b/src/components/productOverview/productInfo/IconList.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable */
 import React from 'react';
 import { FaFacebook, FaPinterest, FaTwitter } from 'react-icons/fa';
-import styled from 'styled-components';
 import {IconListContainer, Icon} from './ProductInfoStyles.jsx';
 
 const IconList = () => {

--- a/src/components/productOverview/productInfo/Overview.jsx
+++ b/src/components/productOverview/productInfo/Overview.jsx
@@ -11,7 +11,6 @@ import SelectQuantity from '../styleSelector/SelectQuantity.jsx';
 import AddToCart from '../AddToCart/AddToCart.jsx';
 import ExpandedView from '../imageGallery/ExpandedView.jsx';
 import Select from 'react-select';
-import styled from 'styled-components';
 import 'whatwg-fetch';
 import {ProductOverview, ProductInformation, CategoryContainer, CartFeatures, AddToCartFeatures, StarButton, DescriptionContainer} from './ProductInfoStyles.jsx';
 

--- a/src/components/productOverview/productInfo/ProductInfo.jsx
+++ b/src/components/productOverview/productInfo/ProductInfo.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable */
 import React from 'react';
-import styled from 'styled-components';
 import {ProductDescriptionContainer, ProductDescriptionTitle} from './ProductInfoStyles.jsx';
 
 const ProductInfo = ({ currentItem }) => {

--- a/src/components/productOverview/styleSelector/SelectQuantity.jsx
+++ b/src/components/productOverview/styleSelector/SelectQuantity.jsx
@@ -2,13 +2,13 @@
 import React from 'react';
 import Select from 'react-select';
 import styled from 'styled-components';
-import {QuantityDiv} from './StyleSelectorStyles.jsx';
+import {QuantityDiv, SelectSizing} from './StyleSelectorStyles.jsx';
 import {IoIosArrowDown} from 'react-icons/io';
 
 const customStyles = {
   option: () => ({}),
   control: () => ({
-    textAlign: 'center'
+    textAlign: 'center',
   }),
 }
 
@@ -23,14 +23,18 @@ const SelectQuantity = ({ currentSize, currentStyle, onQuantityChange }) => {
     }
     return (
       <QuantityDiv>
-        <Select components={{ DropdownIndicator:() => null, IndicatorSeparator:() => null }} options={quantityList} styles={customStyles} placeholder={<div style={{color: 'black'}}>1</div>}></Select>
+        <SelectSizing>
+          <Select components={{ DropdownIndicator:() => null, IndicatorSeparator:() => null}} options={quantityList} styles={customStyles} placeholder={<div style={{color: 'black', textAlign: 'left'}}>1</div>}></Select>
+        </SelectSizing>
         <div><IoIosArrowDown/></div>
       </QuantityDiv>
     )
   }
   return(
     <QuantityDiv>
-      <Select components={{ DropdownIndicator:() => null, IndicatorSeparator:() => null }} styles={customStyles} className='select-quantity' isDisabled placeholder={<div style={{color: 'black'}}>-</div>}></Select>
+      <SelectSizing>
+        <Select components={{ DropdownIndicator:() => null, IndicatorSeparator:() => null }} styles={customStyles} isDisabled placeholder={<div style={{color: 'black', textAlign: 'left'}}>-</div>}></Select>
+      </SelectSizing>
       <div><IoIosArrowDown/></div>
     </QuantityDiv>
   );

--- a/src/components/productOverview/styleSelector/SelectQuantity.jsx
+++ b/src/components/productOverview/styleSelector/SelectQuantity.jsx
@@ -1,14 +1,13 @@
 /* eslint-disable */
 import React from 'react';
 import Select from 'react-select';
-import styled from 'styled-components';
 import {QuantityDiv, SelectSizing} from './StyleSelectorStyles.jsx';
 import {IoIosArrowDown} from 'react-icons/io';
 
 const customStyles = {
   option: () => ({}),
   control: () => ({
-    textAlign: 'center',
+    textAlign: 'left',
   }),
 }
 

--- a/src/components/productOverview/styleSelector/SelectSize.jsx
+++ b/src/components/productOverview/styleSelector/SelectSize.jsx
@@ -2,13 +2,12 @@
 import React, { useState } from 'react';
 import Select from 'react-select';
 import styled from 'styled-components';
-import {SizeDiv} from './StyleSelectorStyles.jsx';
+import {SizeDiv, SelectSizing} from './StyleSelectorStyles.jsx';
 import {IoIosArrowDown} from 'react-icons/io';
 
 const customStyles = {
-  option: () => ({}),
   control: () => ({
-    all: 'unset',
+    width: '80%',
     fontFamily: '"Roboto", sans-serif',
     fontWeight: '300',
   }),
@@ -29,15 +28,19 @@ const SelectSize = ({ openMenuOnFocus, selectRef, currentStyle, onSizeChange }) 
   if (sizes.length) {
     return (
       <SizeDiv>
-        <Select  components={{ DropdownIndicator:() => null, IndicatorSeparator:() => null }} options={options} ref={selectRef} openMenuOnFocus={true} styles={customStyles} onChange={(event) => onSizeChange(event)} placeholder={<div style={{color: 'black'}}>Size</div>}>
-        </Select>
+        <SelectSizing>
+          <Select  components={{ DropdownIndicator:() => null, IndicatorSeparator:() => null}} options={options} ref={selectRef} openMenuOnFocus={true} styles={customStyles} onChange={(event) => onSizeChange(event)} placeholder={<div style={{color: 'black'}}>Size</div>}>
+          </Select>
+        </SelectSizing>
         <div><IoIosArrowDown/></div>
       </SizeDiv>
     );
   }
   return(
     <SizeDiv>
-      <Select components={{ DropdownIndicator:() => null, IndicatorSeparator:() => null }} options={{value: '', label: ''}}  styles={customStyles} isDisabled placeholder={<div style={{color: 'black'}}>Out of Stock</div>}></Select>
+      <SelectSizing>
+        <Select components={{ DropdownIndicator:() => null, IndicatorSeparator:() => null }} options={{value: '', label: ''}}  styles={customStyles} isDisabled placeholder={<div style={{color: 'black'}}>Out of Stock</div>}></Select>
+      </SelectSizing>
       <div><IoIosArrowDown/></div>
     </SizeDiv>
   )

--- a/src/components/productOverview/styleSelector/SelectSize.jsx
+++ b/src/components/productOverview/styleSelector/SelectSize.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable */
 import React, { useState } from 'react';
 import Select from 'react-select';
-import {SizeDiv, SelectSizing} from './StyleSelectorStyles.jsx';
+import {SizeDiv, SelectSizing, SelectPlaceholder} from './StyleSelectorStyles.jsx';
 import {IoIosArrowDown} from 'react-icons/io';
 
 const customStyles = {
@@ -28,7 +28,7 @@ const SelectSize = ({ openMenuOnFocus, selectRef, currentStyle, onSizeChange }) 
     return (
       <SizeDiv>
         <SelectSizing>
-          <Select  components={{ DropdownIndicator:() => null, IndicatorSeparator:() => null}} options={options} ref={selectRef} openMenuOnFocus={true} styles={customStyles} onChange={(event) => onSizeChange(event)} placeholder={<div style={{color: 'black'}}>Size</div>}>
+          <Select components={{ DropdownIndicator:() => null, IndicatorSeparator:() => null}} options={options} ref={selectRef} openMenuOnFocus={true} styles={customStyles} onChange={(event) => onSizeChange(event)} placeholder={<SelectPlaceholder>Size</SelectPlaceholder>}>
           </Select>
         </SelectSizing>
         <div><IoIosArrowDown/></div>
@@ -38,7 +38,7 @@ const SelectSize = ({ openMenuOnFocus, selectRef, currentStyle, onSizeChange }) 
   return(
     <SizeDiv>
       <SelectSizing>
-        <Select components={{ DropdownIndicator:() => null, IndicatorSeparator:() => null }} options={{value: '', label: ''}}  styles={customStyles} isDisabled placeholder={<div style={{color: 'black'}}>Out of Stock</div>}></Select>
+        <Select components={{ DropdownIndicator:() => null, IndicatorSeparator:() => null }} options={{value: '', label: ''}}  styles={customStyles} isDisabled placeholder={<SelectPlaceholder>Out of Stock</SelectPlaceholder>}></Select>
       </SelectSizing>
       <div><IoIosArrowDown/></div>
     </SizeDiv>

--- a/src/components/productOverview/styleSelector/SelectSize.jsx
+++ b/src/components/productOverview/styleSelector/SelectSize.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable */
 import React, { useState } from 'react';
 import Select from 'react-select';
-import styled from 'styled-components';
 import {SizeDiv, SelectSizing} from './StyleSelectorStyles.jsx';
 import {IoIosArrowDown} from 'react-icons/io';
 

--- a/src/components/productOverview/styleSelector/StyleSelectorStyles.jsx
+++ b/src/components/productOverview/styleSelector/StyleSelectorStyles.jsx
@@ -28,6 +28,15 @@ export const StyleCircleSelected = styled.img`
   border-radius: 50%;
 `;
 
+export const SelectSizing = styled.div`
+  width: 80%;
+  display: block;
+  height: 100%;
+  width: 100%;
+  text-decoration: none;
+  text-align: start;
+`;
+
 // Select Size Styles
 export const SizeDiv = styled.div`
   -webkit-appearance: none;
@@ -36,7 +45,7 @@ export const SizeDiv = styled.div`
   align-items: flex-end;
   max-height: 100%;
   width: 60%;
-  padding:0.35em 1.2em;
+  padding:0.35em;
   border:0.1em solid black;
   margin:0 0.3em 0.3em 0;
   border-radius: 3px;
@@ -58,7 +67,7 @@ export const QuantityDiv = styled.div`
   justify-content: space-between;
   align-items: flex-end;
   width: 35%;
-  padding:0.35em 1.2em;
+  padding:0.35em;
   border:0.1em solid black;
   margin:0 0.3em 0.3em 0;
   border-radius: 3px;

--- a/src/components/productOverview/styleSelector/StyleSelectorStyles.jsx
+++ b/src/components/productOverview/styleSelector/StyleSelectorStyles.jsx
@@ -37,6 +37,10 @@ export const SelectSizing = styled.div`
   text-align: start;
 `;
 
+export const SelectPlaceholder = styled.div`
+  color: black;
+`;
+
 // Select Size Styles
 export const SizeDiv = styled.div`
   -webkit-appearance: none;
@@ -45,10 +49,12 @@ export const SizeDiv = styled.div`
   align-items: flex-end;
   max-height: 100%;
   width: 60%;
+  background-color: white;
+  color: black;
   padding:0.35em;
   border:0.1em solid black;
   margin:0 0.3em 0.3em 0;
-  border-radius: 3px;
+  border-radius: 10px;
   text-align: center;
   box-sizing: border-box;
   box-shadow: 0 0 2px black;
@@ -56,7 +62,7 @@ export const SizeDiv = styled.div`
   font-family:'Roboto',sans-serif;
   font-weight:300;
   &:hover {
-    box-shadow: 0 0 5px rgb(222, 99, 23);
+    box-shadow: 0 0 5px rgb(59, 167, 184);
   }
 `;
 
@@ -70,7 +76,7 @@ export const QuantityDiv = styled.div`
   padding:0.35em;
   border:0.1em solid black;
   margin:0 0.3em 0.3em 0;
-  border-radius: 3px;
+  border-radius: 10px;
   text-align: center;
   box-sizing: border-box;
   box-shadow: 0 0 2px black;
@@ -78,6 +84,6 @@ export const QuantityDiv = styled.div`
   font-family:'Roboto',sans-serif;
   font-weight:300;
   &:hover {
-    box-shadow: 0 0 5px rgb(222, 99, 23);
+    box-shadow: 0 0 5px rgb(59, 167, 184);
   }
 `;

--- a/src/components/productOverview/styleSelector/StylesRow.jsx
+++ b/src/components/productOverview/styleSelector/StylesRow.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable */
 import React from 'react';
-import styled from 'styled-components';
 import {BsCheck2Circle} from 'react-icons/bs';
 import {StyleCircleRow, StyleCircle, StyleCircleSelected} from './StyleSelectorStyles.jsx';
 

--- a/src/index.css
+++ b/src/index.css
@@ -148,7 +148,7 @@ body {
   margin-top: 10px;
   margin-bottom: 10px;
   box-shadow: 0 0 5px black;
-  border-radius: 3px;
+  border-radius: 10px;
   cursor: zoom-in;
   animation-duration: 500ms;
   animation-name: fadeIn;


### PR DESCRIPTION
- restyle select dropdowns so that the options take up a larger portion of the width on click, also align the text inside in a manner more consistent with what the client wants
- remove styled-components import from all files apart from styles files
- change styles for buttons - reverted back because react-select is really difficult to style, wont use again
